### PR TITLE
Fix logs being saved to the wrong folder

### DIFF
--- a/src/main/java/org/jmhsrobotics/frc2023/Robot.java
+++ b/src/main/java/org/jmhsrobotics/frc2023/Robot.java
@@ -34,16 +34,18 @@ public class Robot extends TimedRobot {
 	 */
 	@Override
 	public void robotInit() {
-		// Instantiate our RobotContainer. This will perform all our button bindings,
-		// and put our
-		// autonomous chooser on the dashboard.
-		m_robotContainer = new RobotContainer();
-		m_robotContainer.getDrivetrain().setBrake(false);
+		// This code must be the first thing that runs otherwise the directory is not
+		// updated
 		if (Robot.isSimulation()) {
 			DataLogManager.start(Filesystem.getOperatingDirectory().getAbsolutePath() + "\\logs");
 		} else {
 			DataLogManager.start();
 		}
+		// Instantiate our RobotContainer. This will perform all our button bindings,
+		// and put our
+		// autonomous chooser on the dashboard.
+		m_robotContainer = new RobotContainer();
+		m_robotContainer.getDrivetrain().setBrake(false);
 
 		// Enables network table logging for data
 		DataLogManager.logNetworkTables(true);


### PR DESCRIPTION
This fixes a bug where the logger is started before the output directory is set. Causing code to configure the output directory to fail.